### PR TITLE
Add a map of LUGs using the jekyll-maps plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
 gem 'jekyll', '3.8.4' # this is the Jekyll version we are working with
+gem 'jekyll-maps'
 # gem 'nokogiri', '1.6.7.2' # Nokogiri is a dependency that might cause errors if it's not added to the script
 gem 'html-proofer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,8 @@ GEM
       pathutil (~> 0.9)
       rouge (>= 1.7, < 4)
       safe_yaml (~> 1.0)
+    jekyll-maps (2.3.0)
+      jekyll (~> 3.0)
     jekyll-sass-converter (1.5.2)
       sass (~> 3.4)
     jekyll-watch (2.0.0)
@@ -87,6 +89,7 @@ PLATFORMS
 DEPENDENCIES
   html-proofer
   jekyll (= 3.8.4)
+  jekyll-maps
 
 BUNDLED WITH
    2.0.1

--- a/_config.yml
+++ b/_config.yml
@@ -97,3 +97,12 @@ t:
       october: "Oct"
       november: "Nov"
       december : "Dec"
+
+plugins:
+  - jekyll-maps
+
+# Google Maps API key managed by Tim Retout
+# Restricted to lug.org.uk domains, and 127.0.0.1:4000
+maps:
+  google:
+    api_key: "AIzaSyD5LJcVn9SC9JUxT6dS-dXYEVRYTl9PJBQ"

--- a/_layouts/lug.html
+++ b/_layouts/lug.html
@@ -32,3 +32,7 @@ layout: default
 </p>
 
 {{ content }}
+
+{% if page.location %}
+{% google_map zoom="7" %}
+{% endif %}

--- a/_posts/0000-01-01-Aberdeen.md
+++ b/_posts/0000-01-01-Aberdeen.md
@@ -11,4 +11,7 @@ contact_address: mailto:mark@arricc.net
 contact: Mark McRitchie
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/aberdeen/
 permalink: lugs/Scotland/Aberdeen/
+location:
+  latitude: 57.15
+  longitude: -2.09
 ---

--- a/_posts/0000-01-01-Anglian LUG.md
+++ b/_posts/0000-01-01-Anglian LUG.md
@@ -11,4 +11,7 @@ contact_address: mailto:main-admin@lists.alug.org.uk
 contact: ALUG Admin Team
 mailing_list: http://lists.alug.org.uk/mailman/listinfo/main
 permalink: lugs/East/Anglian LUG/
+location:
+  latitude: 52.63
+  longitude: 1.30
 ---

--- a/_posts/0000-01-01-Bassetlaw.md
+++ b/_posts/0000-01-01-Bassetlaw.md
@@ -11,4 +11,7 @@ contact_address: mailto:dannyroberts.personal@googlemail.com
 contact: Danny Roberts
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/bassetlug/
 permalink: lugs/East-Midlands/Bassetlaw/
+location:
+  latitude: 53.31
+  longitude: -1.12
 ---

--- a/_posts/0000-01-01-Belfast.md
+++ b/_posts/0000-01-01-Belfast.md
@@ -11,4 +11,7 @@ contact_address: mailto:info@belfastlinux.org
 contact: info@belfastlinux.org
 mailing_list: http://www.belfastlinux.org/list.html
 permalink: lugs/Northern-Ireland/Belfast/
+location:
+  latitude: 54.60
+  longitude: -5.93
 ---

--- a/_posts/0000-01-01-Berkshire & Thames Valley Silicon Corridor.md
+++ b/_posts/0000-01-01-Berkshire & Thames Valley Silicon Corridor.md
@@ -11,4 +11,7 @@ contact_address: mailto:tmdg@tmdg.co.uk
 contact: Tom Dawes-Gamble
 mailing_list: http://sclug.org.uk/mailman/listinfo
 permalink: lugs/South-East/Berkshire and Thames Valley - Silicon Corridor/
+location:
+  latitude: 51.45
+  longitude: -0.98
 ---

--- a/_posts/0000-01-01-Birmingham.md
+++ b/_posts/0000-01-01-Birmingham.md
@@ -11,4 +11,7 @@ contact_address: mailto:bhamlug@autotrain.org
 contact: LUG Master
 mailing_list: http://mailman.lug.org.uk/mailman/listinfo/sb
 permalink: lugs/West-Midlands/Birmingham/
+location:
+  latitude: 52.49
+  longitude: -1.89
 ---

--- a/_posts/0000-01-01-Blackpool.md
+++ b/_posts/0000-01-01-Blackpool.md
@@ -11,4 +11,7 @@ contact_address: mailto:admin@pcrecycler.co.uk
 contact: Mike Hewitt
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/blackpool/
 permalink: lugs/North-West/Blackpool/
+location:
+  latitude: 53.82
+  longitude: -3.04
 ---

--- a/_posts/0000-01-01-Bradford.md
+++ b/_posts/0000-01-01-Bradford.md
@@ -11,4 +11,7 @@ contact_address: mailto:admin@bradlug.co.uk
 contact: David Carpenter
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/bradford/
 permalink: lugs/Yorkshire-and-Humber/Bradford/
+location:
+  latitude: 53.80
+  longitude: -1.76
 ---

--- a/_posts/0000-01-01-Brighton.md
+++ b/_posts/0000-01-01-Brighton.md
@@ -11,4 +11,7 @@ contact_address: mailto:js@jswan.demon.co.uk
 contact: Johnathan Swan
 mailing_list: http://lists.ourshack.com/mailman/listinfo/brighton-lug-misc
 permalink: lugs/South-East/Brighton/
+location:
+  latitude: 50.82
+  longitude: -0.14
 ---

--- a/_posts/0000-01-01-Bristol and Bath.md
+++ b/_posts/0000-01-01-Bristol and Bath.md
@@ -11,4 +11,7 @@ contact_address: mailto:daved@studley-halls.demon.co.uk
 contact: Dave Donaghy
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/bristol/
 permalink: lugs/South-West/Bristol and Bath/
+location:
+  latitude: 51.45
+  longitude: -2.59
 ---

--- a/_posts/0000-01-01-Brixton.md
+++ b/_posts/0000-01-01-Brixton.md
@@ -10,4 +10,7 @@ url: http://lug.org.uk/node/68
 contact_address: mailto:solar3sn@netscape.net
 contact: R.M. Sanchez
 permalink: lugs/London/Brixton/
+location:
+  latitude: 51.46
+  longitude: -0.12
 ---

--- a/_posts/0000-01-01-Cambridge.md
+++ b/_posts/0000-01-01-Cambridge.md
@@ -11,4 +11,7 @@ contact_address: mailto:paul@the-hug.org
 contact: Paul Oldham
 mailing_list: https://the-hug.net/lists/clug
 permalink: lugs/East/Cambridge/
+location:
+  latitude: 52.21
+  longitude: 0.12
 ---

--- a/_posts/0000-01-01-Chelmer Linux and Android Users Group.md
+++ b/_posts/0000-01-01-Chelmer Linux and Android Users Group.md
@@ -11,4 +11,7 @@ contact_address: mailto:lugmaster@chelmer.lug.org.uk
 contact: Martin Houston
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/chelmer/
 permalink: lugs/South-East/Chelmer Linux and Android Users Group/
+location:
+  latitude: 51.74
+  longitude: 0.47
 ---

--- a/_posts/0000-01-01-Cheshire (South).md
+++ b/_posts/0000-01-01-Cheshire (South).md
@@ -11,4 +11,7 @@ contact_address: mailto:richard@sc.lug.org.uk
 contact: Richard Smedley
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/sc/
 permalink: lugs/North-West/Cheshire (South)/
+location:
+  latitude: 53.23
+  longitude: -2.61
 ---

--- a/_posts/0000-01-01-Chester.md
+++ b/_posts/0000-01-01-Chester.md
@@ -11,4 +11,7 @@ contact_address: mailto:les.pritchard@gmail.com
 contact: Les Pritchard
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/chester/
 permalink: lugs/North-West/Chester/
+location:
+  latitude: 53.19
+  longitude: -2.89
 ---

--- a/_posts/0000-01-01-Colchester.md
+++ b/_posts/0000-01-01-Colchester.md
@@ -11,4 +11,7 @@ contact_address: mailto:colchester@lug.org.uk
 contact: Gary Kearley
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/colchester/
 permalink: lugs/East/Colchester/
+location:
+  latitude: 51.90
+  longitude: 0.89
 ---

--- a/_posts/0000-01-01-Coventry.md
+++ b/_posts/0000-01-01-Coventry.md
@@ -11,4 +11,7 @@ contact_address: mailto:info@covlug.org.uk
 contact: Darren Austin
 mailing_list: http://www.covlug.org.uk/mailinglist.html
 permalink: lugs/West-Midlands/Coventry/
+location:
+  latitude: 52.41
+  longitude: -1.52
 ---

--- a/_posts/0000-01-01-Cowley Club, Brighton.md
+++ b/_posts/0000-01-01-Cowley Club, Brighton.md
@@ -10,4 +10,7 @@ url: http://lug.org.uk/node/187
 contact_address: mailto:cowleylibrary@riseup.net
 contact: Cowley Library Volunteers
 permalink: lugs/South-East/Cowley Club, Brighton/
+location:
+  latitude: 50.8303
+  longitude: -0.1362
 ---

--- a/_posts/0000-01-01-Cumbria.md
+++ b/_posts/0000-01-01-Cumbria.md
@@ -11,4 +11,7 @@ contact_address: mailto:schwuk@cumbria.lug.org.uk
 contact: David Murphy
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/cumbria/
 permalink: lugs/North-West/Cumbria/
+location:
+  latitude: 54.58
+  longitude: -2.80
 ---

--- a/_posts/0000-01-01-Derbyshire - South.md
+++ b/_posts/0000-01-01-Derbyshire - South.md
@@ -11,4 +11,7 @@ contact_address: mailto:clare.lou1985@googlemail.com
 contact: Clare Currie
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/sderby/
 permalink: lugs/East-Midlands/Derbyshire - South/
+location:
+  latitude: 52.92
+  longitude: -1.47
 ---

--- a/_posts/0000-01-01-Derry.md
+++ b/_posts/0000-01-01-Derry.md
@@ -11,4 +11,7 @@ contact_address: mailto:dlug@ntlworld.com
 contact: Robert Brown
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/derry/
 permalink: lugs/Northern-Ireland/Derry/
+location:
+  latitude: 55.00
+  longitude: -7.31
 ---

--- a/_posts/0000-01-01-Devon and Cornwall.md
+++ b/_posts/0000-01-01-Devon and Cornwall.md
@@ -11,4 +11,7 @@ contact_address: "/admin%40dclug.org.uk"
 contact: DCLUG
 mailing_list: http://mailman.dcglug.org.uk/listinfo/list
 permalink: lugs/South-West/Devon and Cornwall/
+location:
+  latitude: 50.38
+  longitude: -4.14
 ---

--- a/_posts/0000-01-01-Doncaster & Scunthorpe.md
+++ b/_posts/0000-01-01-Doncaster & Scunthorpe.md
@@ -10,4 +10,7 @@ url: http://lug.org.uk/node/129
 contact_address: mailto:webmaster@scundog.org
 contact: Shaun Holt
 permalink: lugs/Yorkshire-and-Humber/Doncaster & Scunthorpe/
+location:
+  latitude: 53.52
+  longitude: -1.13
 ---

--- a/_posts/0000-01-01-Dorset.md
+++ b/_posts/0000-01-01-Dorset.md
@@ -11,4 +11,7 @@ contact_address: lugmaster@dorset.lug.org.uk
 contact: LUG Master
 mailing_list: http://mailman.lug.org.uk/mailman/listinfo/dorset
 permalink: lugs/South-West/Dorset/
+location:
+  latitude: 50.75
+  longitude: -2.34
 ---

--- a/_posts/0000-01-01-Dundee & Tayside.md
+++ b/_posts/0000-01-01-Dundee & Tayside.md
@@ -11,4 +11,7 @@ contact_address: mailto:astrozubenel@googlemail.com
 contact: Gordon Dunlop
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/dundee/
 permalink: lugs/Scotland/Dundee & Tayside/
+location:
+  latitude: 56.46
+  longitude: -2.97
 ---

--- a/_posts/0000-01-01-Durham.md
+++ b/_posts/0000-01-01-Durham.md
@@ -11,4 +11,7 @@ contact_address: mailto:nelug-admin@nelug.org.uk
 contact: Richard Patterson
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/nelug/
 permalink: lugs/North-East/Durham/
+location:
+  latitude: 54.78
+  longitude: -1.58
 ---

--- a/_posts/0000-01-01-East Grinstead.md
+++ b/_posts/0000-01-01-East Grinstead.md
@@ -11,4 +11,7 @@ contact_address: mailto:fay@eglug.org.uk
 contact: Frances Fleming
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/eg/
 permalink: lugs/South-East/East Grinstead/
+location:
+  latitude: 51.13
+  longitude: -0.01
 ---

--- a/_posts/0000-01-01-East Hertfordshire.md
+++ b/_posts/0000-01-01-East Hertfordshire.md
@@ -11,4 +11,7 @@ contact_address: mailto:madtom1999@yahoo.com
 contact: Tom Potts
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/ear/
 permalink: lugs/East/East Hertfordshire/
+location:
+  latitude: 51.87
+  longitude: 0.15
 ---

--- a/_posts/0000-01-01-Edinburgh.md
+++ b/_posts/0000-01-01-Edinburgh.md
@@ -11,4 +11,7 @@ contact_address: mailto:meetings@edlug.org.uk
 contact: Jan Goulding
 mailing_list: http://www.edlug.org.uk/list_faq.html#howtojoin
 permalink: lugs/Scotland/Edinburgh/
+location:
+  latitude: 55.95
+  longitude: -3.19
 ---

--- a/_posts/0000-01-01-Exeter.md
+++ b/_posts/0000-01-01-Exeter.md
@@ -11,4 +11,7 @@ contact_address: mailto:ricktimmis68@googlmail.com
 contact: Rick Timmis
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/exeter
 permalink: lugs/South-West/Exeter/
+location:
+  latitude: 50.72
+  longitude: -3.53
 ---

--- a/_posts/0000-01-01-Falkirk.md
+++ b/_posts/0000-01-01-Falkirk.md
@@ -11,4 +11,7 @@ contact_address: mailto:flug@emeraldreverie.org
 contact: Greg Sutcliffe
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/falkirk/
 permalink: lugs/Scotland/Falkirk/
+location:
+  latitude: 56.00
+  longitude: -3.78
 ---

--- a/_posts/0000-01-01-Glastonbury.md
+++ b/_posts/0000-01-01-Glastonbury.md
@@ -11,4 +11,7 @@ contact_address: mailto:sean@seanmiller.net
 contact: Sean Miller
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/glastonbury
 permalink: lugs/South-West/Glastonbury/
+location:
+  latitude: 51.15
+  longitude: -2.72
 ---

--- a/_posts/0000-01-01-Gloucestershire & Cotswolds.md
+++ b/_posts/0000-01-01-Gloucestershire & Cotswolds.md
@@ -11,4 +11,7 @@ contact_address: mailto:glynd@walmore.com
 contact: Glyn Davies
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/gloucs/
 permalink: lugs/South-West/Gloucestershire & Cotswolds/
+location:
+  latitude: 51.86
+  longitude: -2.24
 ---

--- a/_posts/0000-01-01-Greater London (GLLUG).md
+++ b/_posts/0000-01-01-Greater London (GLLUG).md
@@ -11,4 +11,7 @@ contact_address: mailto:mattcopp+gllug@gmail.com
 contact: Matt Copperwaite
 mailing_list: http://mailman.lug.org.uk/mailman/listinfo/gllug
 permalink: lugs/London/Greater London (GLLUG)/
+location:
+  latitude: 51.43
+  longitude: -0.09
 ---

--- a/_posts/0000-01-01-Hants.md
+++ b/_posts/0000-01-01-Hants.md
@@ -11,4 +11,7 @@ contact_address: mailto:adam.trickett@iredale.net
 contact: Adam Trickett
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/hants/
 permalink: lugs/South-East/Hants/
+location:
+  latitude: 51.06
+  longitude: -1.31
 ---

--- a/_posts/0000-01-01-Herefordshire.md
+++ b/_posts/0000-01-01-Herefordshire.md
@@ -11,4 +11,7 @@ contact_address: mailto:joolsr1@gmail.com
 contact: Julian Robbins
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/herefordshire/
 permalink: lugs/West-Midlands/Herefordshire/
+location:
+  latitude: 52.08
+  longitude: -2.65
 ---

--- a/_posts/0000-01-01-Hertfordshire.md
+++ b/_posts/0000-01-01-Hertfordshire.md
@@ -11,4 +11,7 @@ contact_address: mailto:herts@lug.org.uk
 contact: Nicolas Pike
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/herts/
 permalink: lugs/East/Hertfordshire/
+location:
+  latitude: 51.90
+  longitude: -0.20
 ---

--- a/_posts/0000-01-01-Isle Of Man.md
+++ b/_posts/0000-01-01-Isle Of Man.md
@@ -11,4 +11,7 @@ contact_address: mailto:mr.dan.wood@gmail.com
 contact: Dan Wood
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/iom
 permalink: lugs/North-West/Isle Of Man/
+location:
+  latitude: 54.24
+  longitude: -4.55
 ---

--- a/_posts/0000-01-01-Isle of Wight.md
+++ b/_posts/0000-01-01-Isle of Wight.md
@@ -10,4 +10,7 @@ url: http://lug.org.uk/node/186
 contact_address: mailto:rogerskid@supanet.com
 contact: Roger Skidmore
 permalink: lugs/South-East/Isle of Wight/
+location:
+  latitude: 50.69
+  longitude: -1.30
 ---

--- a/_posts/0000-01-01-Kent.md
+++ b/_posts/0000-01-01-Kent.md
@@ -11,4 +11,7 @@ contact_address: mailto:danattwood@googlemail.com
 contact: Dan Attwood
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/kent/
 permalink: lugs/South-East/Kent/
+location:
+  latitude: 51.28
+  longitude: 0.52
 ---

--- a/_posts/0000-01-01-Lancaster.md
+++ b/_posts/0000-01-01-Lancaster.md
@@ -11,4 +11,7 @@ contact_address: mailto:info@lancasterlug.org.uk
 contact: Wayne Ward
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/lancaster/
 permalink: lugs/North-West/Lancaster/
+location:
+  latitude: 54.05
+  longitude: -2.80
 ---

--- a/_posts/0000-01-01-Leicester.md
+++ b/_posts/0000-01-01-Leicester.md
@@ -11,4 +11,7 @@ contact_address: mailto:clive@leicester.lug.org.uk
 contact: Clive Jones
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/leicester/
 permalink: lugs/East-Midlands/Leicester/
+location:
+  latitude: 52.64
+  longitude: -1.14
 ---

--- a/_posts/0000-01-01-Leigh.md
+++ b/_posts/0000-01-01-Leigh.md
@@ -11,4 +11,7 @@ contact_address: mailto:aura.yoda@gmail.com
 contact: Phil Wyett
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/leigh
 permalink: lugs/North-West/Leigh/
+location:
+  latitude: 53.50
+  longitude: -2.52
 ---

--- a/_posts/0000-01-01-Lincoln.md
+++ b/_posts/0000-01-01-Lincoln.md
@@ -11,4 +11,7 @@ contact_address: mailto:bobobex@bobobex.org
 contact: Becky Newborough
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/lincoln
 permalink: lugs/East-Midlands/Lincoln/
+location:
+  latitude: 53.23
+  longitude: -0.54
 ---

--- a/_posts/0000-01-01-Lincolnshire.md
+++ b/_posts/0000-01-01-Lincolnshire.md
@@ -11,4 +11,7 @@ contact_address: mailto:iain.dbaker@gmail.com
 contact: Iain Baker
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/lincs/
 permalink: lugs/East-Midlands/Lincolnshire/
+location:
+  latitude: 52.95
+  longitude: -0.16
 ---

--- a/_posts/0000-01-01-Liverpool (LivLUG).md
+++ b/_posts/0000-01-01-Liverpool (LivLUG).md
@@ -11,4 +11,7 @@ contact_address: mailto:neil@stfw.net
 contact: Neil Bothwick
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/liverpool/
 permalink: lugs/North-West/Liverpool (LivLUG)/
+location:
+  latitude: 53.41
+  longitude: -2.99
 ---

--- a/_posts/0000-01-01-London (LONIX).md
+++ b/_posts/0000-01-01-London (LONIX).md
@@ -10,4 +10,7 @@ url: http://lug.org.uk/node/71
 contact_address: mailto:tjoshi@lonix.org.uk
 contact: Tushar Joshi
 permalink: lugs/London/London (LONIX)/
+location:
+  latitude: 51.51
+  longitude: -0.13
 ---

--- a/_posts/0000-01-01-Malvern.md
+++ b/_posts/0000-01-01-Malvern.md
@@ -11,4 +11,7 @@ contact_address: mailto:phil@cstf.co.uk
 contact: Phil Ironside
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/malvern/
 permalink: lugs/West-Midlands/Malvern/
+location:
+  latitude: 52.14
+  longitude: -2.32
 ---

--- a/_posts/0000-01-01-Manchester Free Software.md
+++ b/_posts/0000-01-01-Manchester Free Software.md
@@ -11,4 +11,7 @@ contact_address: mailto:fsuk-manchester-team@nongnu.org
 contact: Team MFS
 mailing_list: http://lists.nongnu.org/mailman/listinfo/fsuk-manchester
 permalink: lugs/North-West/Manchester Free Software/
+location:
+  latitude: 53.48
+  longitude: -2.23
 ---

--- a/_posts/0000-01-01-Manchester.md
+++ b/_posts/0000-01-01-Manchester.md
@@ -11,4 +11,7 @@ contact_address: http://www.manlug.org/?page_id=809
 contact: http://www.manlug.org/?page_id=809
 mailing_list: http://listserv.manchester.ac.uk/cgi-bin/wa?SUBED1=man-lug&amp;A=1
 permalink: lugs/North-West/Manchester/
+location:
+  latitude: 53.48
+  longitude: -2.24
 ---

--- a/_posts/0000-01-01-Mansfield.md
+++ b/_posts/0000-01-01-Mansfield.md
@@ -11,4 +11,7 @@ contact_address: mailto:mansfield@lug.org.uk
 contact: Brent Vardy
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/mansfield/
 permalink: lugs/East-Midlands/Mansfield/
+location:
+  latitude: 53.15
+  longitude: -1.20
 ---

--- a/_posts/0000-01-01-Menai.md
+++ b/_posts/0000-01-01-Menai.md
@@ -11,4 +11,7 @@ contact_address: mailto:kevin@dotmon.com
 contact: Kevin Donnelly
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/menai/
 permalink: lugs/Wales/Menai/
+location:
+  latitude: 53.23
+  longitude: -4.13
 ---

--- a/_posts/0000-01-01-Milton Keynes.md
+++ b/_posts/0000-01-01-Milton Keynes.md
@@ -11,4 +11,7 @@ contact_address: mailto:info@mk.lug.org.uk
 contact: Gavin Westwood
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/mk/
 permalink: lugs/South-East/Milton Keynes/
+location:
+  latitude: 52.04
+  longitude: -0.76
 ---

--- a/_posts/0000-01-01-Newark.md
+++ b/_posts/0000-01-01-Newark.md
@@ -11,4 +11,7 @@ contact_address: mailto:c_lynch87@outlook.com
 contact: Craig Lynch
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/newark/
 permalink: lugs/East-Midlands/Newark/
+location:
+  latitude: 53.07
+  longitude: -0.81
 ---

--- a/_posts/0000-01-01-North East Worcestershire.md
+++ b/_posts/0000-01-01-North East Worcestershire.md
@@ -11,4 +11,7 @@ contact_address: mailto:neworcslug@gmail.com
 contact: Doug Mills
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/newlug
 permalink: lugs/West-Midlands/North-East Worcestershire/
+location:
+  latitude: 52.22
+  longitude: -1.87
 ---

--- a/_posts/0000-01-01-North Wales.md
+++ b/_posts/0000-01-01-North Wales.md
@@ -11,4 +11,7 @@ contact_address: mailto:info@nwlug.org.uk
 contact: Andrew Hutchings
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/northwales/
 permalink: lugs/Wales/North-Wales/
+location:
+  latitude: 53.07
+  longitude: -3.81
 ---

--- a/_posts/0000-01-01-North of Scotland.md
+++ b/_posts/0000-01-01-North of Scotland.md
@@ -10,4 +10,7 @@ url: http://lug.org.uk/node/111
 contact_address: mailto:skfscotlad@aol.com
 contact: Stephen Kenneth Fuller
 permalink: lugs/Scotland/North of Scotland/
+location:
+  latitude: 57.48
+  longitude: -4.22
 ---

--- a/_posts/0000-01-01-North-West London.md
+++ b/_posts/0000-01-01-North-West London.md
@@ -11,4 +11,7 @@ contact_address: mailto:diamond@fastmail.fm
 contact: Diamond Braganza
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/northwestlondon/
 permalink: lugs/London/North-West London/
+location:
+  latitude: 51.58
+  longitude: -0.34
 ---

--- a/_posts/0000-01-01-Northants.md
+++ b/_posts/0000-01-01-Northants.md
@@ -11,4 +11,7 @@ contact_address: mailto:info@northants.lug.org.uk
 contact: Kevin Taylor
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/northants/
 permalink: lugs/East-Midlands/Northants/
+location:
+  latitude: 52.24
+  longitude: -0.90
 ---

--- a/_posts/0000-01-01-Nottingham.md
+++ b/_posts/0000-01-01-Nottingham.md
@@ -11,4 +11,7 @@ contact_address: mailto:nottingham-owner@mailman.lug.org.uk
 contact: Martin Lomas
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/nottingham/
 permalink: lugs/East-Midlands/Nottingham/
+location:
+  latitude: 52.95
+  longitude: -1.16
 ---

--- a/_posts/0000-01-01-Nuneaton.md
+++ b/_posts/0000-01-01-Nuneaton.md
@@ -8,4 +8,7 @@ last_update: 09/2016
 categories: West-Midlands
 url: http://lug.org.uk/node/160
 permalink: lugs/West-Midlands/Nuneaton/
+location:
+  latitude: 52.52
+  longitude: -1.47
 ---

--- a/_posts/0000-01-01-Orkney.md
+++ b/_posts/0000-01-01-Orkney.md
@@ -10,4 +10,7 @@ url: http://lug.org.uk/node/113
 contact_address: mailto:digit.siljrath@googlemail.com
 contact: Digit Siljrath
 permalink: lugs/Scotland/Orkney/
+location:
+  latitude: 58.98
+  longitude: -2.96
 ---

--- a/_posts/0000-01-01-Orpington.md
+++ b/_posts/0000-01-01-Orpington.md
@@ -11,4 +11,7 @@ contact_address: mailto:tony@jonesyhouse.demon.co.uk
 contact: Tony Jones
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/orpington/
 permalink: lugs/South-East/Orpington/
+location:
+  latitude: 51.37
+  longitude: 0.09
 ---

--- a/_posts/0000-01-01-Oxford.md
+++ b/_posts/0000-01-01-Oxford.md
@@ -11,4 +11,7 @@ contact_address: mailto:info@ox.lug.org.uk
 contact: Alasdair G Kergon
 mailing_list: http://lists.oxlug.org/mailman/listinfo/oxlug
 permalink: lugs/South-East/Oxford/
+location:
+  latitude: 51.75
+  longitude: -1.26
 ---

--- a/_posts/0000-01-01-Peterborough.md
+++ b/_posts/0000-01-01-Peterborough.md
@@ -11,4 +11,7 @@ contact_address: mark@more-solutions.co.uk
 contact: Mark Rogers
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/peterboro/
 permalink: lugs/East/Peterborough/
+location:
+  latitude: 52.57
+  longitude: -0.24
 ---

--- a/_posts/0000-01-01-Portsmouth and South East Hampshire.md
+++ b/_posts/0000-01-01-Portsmouth and South East Hampshire.md
@@ -11,4 +11,7 @@ contact_address: mailto:paul@aptanet.com
 contact: Paul Tansom
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/portsmouth/
 permalink: lugs/South-East/Portsmouth and South-East Hampshire/
+location:
+  latitude: 50.82
+  longitude: -1.09
 ---

--- a/_posts/0000-01-01-Powys.md
+++ b/_posts/0000-01-01-Powys.md
@@ -10,4 +10,7 @@ url: http://lug.org.uk/node/152
 contact_address: mailto:info@powyslug.org.uk
 contact: Ray Rand
 permalink: lugs/Wales/Powys/
+location:
+  latitude: 52.65
+  longitude: -3.33
 ---

--- a/_posts/0000-01-01-Preston & Lancashire.md
+++ b/_posts/0000-01-01-Preston & Lancashire.md
@@ -11,4 +11,7 @@ contact_address: mailto:phil@linux-games.co.uk
 contact: Phil Robinson
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/preston/
 permalink: lugs/North-West/Preston & Lancashire/
+location:
+  latitude: 53.76
+  longitude: -2.70
 ---

--- a/_posts/0000-01-01-Rossendale LUG.md
+++ b/_posts/0000-01-01-Rossendale LUG.md
@@ -11,4 +11,7 @@ contact_address: mailto:admin@rosslug.org.uk
 contact: Jon Archer
 mailing_list: http://www.rosslug.org.uk/mailman/listinfo/rosslug
 permalink: lugs/North-West/Rossendale LUG/
+location:
+  latitude: 53.69
+  longitude: -2.26
 ---

--- a/_posts/0000-01-01-Rugby.md
+++ b/_posts/0000-01-01-Rugby.md
@@ -11,4 +11,7 @@ contact_address: mailto:rugby-owner@mailman.lug.org.uk
 contact: Nick Morrott
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/rugby
 permalink: lugs/West-Midlands/Rugby/
+location:
+  latitude: 52.37
+  longitude: -1.27
 ---

--- a/_posts/0000-01-01-Rustington.md
+++ b/_posts/0000-01-01-Rustington.md
@@ -10,4 +10,7 @@ url: http://lug.org.uk/node/175
 contact_address: mailto:fhj@eldy.org
 contact: Frank James
 permalink: lugs/South-East/Rustington/
+location:
+  latitude: 50.80
+  longitude: -0.51
 ---

--- a/_posts/0000-01-01-Ryedale.md
+++ b/_posts/0000-01-01-Ryedale.md
@@ -11,4 +11,7 @@ contact_address: mailto:acg@ryedale.lug.org.uk
 contact: Al Girling
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/ryedale/
 permalink: lugs/Yorkshire-and-Humber/Ryedale/
+location:
+  latitude: 54.17
+  longitude: -0.73
 ---

--- a/_posts/0000-01-01-Scottish.md
+++ b/_posts/0000-01-01-Scottish.md
@@ -11,4 +11,7 @@ contact_address: mailto:info@scotlug.org.uk
 contact: Kenny Duffus
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/scottish/
 permalink: lugs/Scotland/Scottish/
+location:
+  latitude: 55.86
+  longitude: -4.25
 ---

--- a/_posts/0000-01-01-Sheffield Linux User Group and BSD User Group.md
+++ b/_posts/0000-01-01-Sheffield Linux User Group and BSD User Group.md
@@ -11,4 +11,7 @@ contact_address: mailto:slugbug@email-lists.org
 contact: Chris Croome
 mailing_list: http://www.email-lists.org/mailman/listinfo/slugbug
 permalink: lugs/Yorkshire-and-Humber/Sheffield Linux User Group and BSD User Group/
+location:
+  latitude: 53.38
+  longitude: -1.46
 ---

--- a/_posts/0000-01-01-Sheffield.md
+++ b/_posts/0000-01-01-Sheffield.md
@@ -11,4 +11,7 @@ contact_address: mailto:enquiries@sheflug.org.uk
 contact: Richard Ibbotson
 mailing_list: http://sheflug.org.uk/mailman/listinfo/sheflug_sheflug.org.uk
 permalink: lugs/Yorkshire-and-Humber/Sheffield/
+location:
+  latitude: 53.38
+  longitude: -1.47
 ---

--- a/_posts/0000-01-01-Shropshire.md
+++ b/_posts/0000-01-01-Shropshire.md
@@ -11,4 +11,7 @@ contact_address: mailto:davekh@gmail.com
 contact: Dave Harris
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/shropshire
 permalink: lugs/West-Midlands/Shropshire/
+location:
+  latitude: 52.71
+  longitude: -2.74
 ---

--- a/_posts/0000-01-01-South Wales.md
+++ b/_posts/0000-01-01-South Wales.md
@@ -9,4 +9,7 @@ categories: Wales
 url: http://lug.org.uk/node/154
 mailing_list: http://mailman.lug.org.uk/mailman/listinfo/swlug/
 permalink: lugs/Wales/South Wales/
+location:
+  latitude: 51.48
+  longitude: -3.18
 ---

--- a/_posts/0000-01-01-Southend-on-Sea.md
+++ b/_posts/0000-01-01-Southend-on-Sea.md
@@ -11,4 +11,7 @@ contact_address: mailto:linux@soslug.org
 contact: Derek Shaw
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/sos/
 permalink: lugs/South-East/Southend-on-Sea/
+location:
+  latitude: 51.55
+  longitude: 0.71
 ---

--- a/_posts/0000-01-01-St. Andrews.md
+++ b/_posts/0000-01-01-St. Andrews.md
@@ -11,4 +11,7 @@ contact_address: mailto:admin@standrews.lug.org.uk
 contact: Rory Beaton
 mailing_list: http://mailman.lug.org.uk/mailman/listinfo/standrews
 permalink: lugs/Scotland/St. Andrews/
+location:
+  latitude: 56.34
+  longitude: -2.80
 ---

--- a/_posts/0000-01-01-Staffordshire.md
+++ b/_posts/0000-01-01-Staffordshire.md
@@ -11,4 +11,7 @@ contact_address: mailto:dave@staffslug.org.uk
 contact: Dave Roberts
 mailing_list: http://lists.staffslug.org.uk/mailman/listinfo/staffslug
 permalink: lugs/West-Midlands/Staffordshire/
+location:
+  latitude: 52.88
+  longitude: -2.06
 ---

--- a/_posts/0000-01-01-Surrey.md
+++ b/_posts/0000-01-01-Surrey.md
@@ -11,4 +11,7 @@ contact_address: mailto:surrey-owner@mailman.lug.org.uk
 contact: Surrey LUG admin team
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/surrey/
 permalink: lugs/South-East/Surrey/
+location:
+  latitude: 51.31
+  longitude: -0.56
 ---

--- a/_posts/0000-01-01-Sussex.md
+++ b/_posts/0000-01-01-Sussex.md
@@ -11,4 +11,7 @@ contact_address: mailto:steve.dobson@syscall.org.uk
 contact: Steve Dobson
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/sussex/
 permalink: lugs/South-East/Sussex/
+location:
+  latitude: 50.91
+  longitude: 0.25
 ---

--- a/_posts/0000-01-01-Swindon.md
+++ b/_posts/0000-01-01-Swindon.md
@@ -11,4 +11,7 @@ contact_address: mailto:tomearl98@gmail.com
 contact: Tom Earl
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/swindon
 permalink: lugs/South-West/Swindon/
+location:
+  latitude: 51.56
+  longitude: -1.78
 ---

--- a/_posts/0000-01-01-Thanet Linux User Group.md
+++ b/_posts/0000-01-01-Thanet Linux User Group.md
@@ -11,4 +11,7 @@ contact_address: mailto:thanet@lug.org.uk
 contact: Matthew Macdonald-Wallace
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/thanet/
 permalink: lugs/South-East/Thanet Linux User Group/
+location:
+  latitude: 51.36
+  longitude: 1.35
 ---

--- a/_posts/0000-01-01-Tyneside (Newcastle).md
+++ b/_posts/0000-01-01-Tyneside (Newcastle).md
@@ -11,4 +11,7 @@ contact_address: mailto:contact@tyneside.lug.org.uk
 contact: Brian Ronald
 mailing_list: http://tyneside.lug.org.uk/mailman/listinfo
 permalink: lugs/North-East/Tyneside (Newcastle)/
+location:
+  latitude: 54.98
+  longitude: -1.62
 ---

--- a/_posts/0000-01-01-Watford.md
+++ b/_posts/0000-01-01-Watford.md
@@ -11,4 +11,7 @@ contact_address: mailto:cliff.g3ndc@btinternet.com
 contact: Cliff Deamer
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/watford/
 permalink: lugs/London/Watford/
+location:
+  latitude: 51.66
+  longitude: -0.39
 ---

--- a/_posts/0000-01-01-West Berkshire - Newbury.md
+++ b/_posts/0000-01-01-West Berkshire - Newbury.md
@@ -11,4 +11,7 @@ contact_address: mailto:westberkshire@lug.org.uk
 contact: Phillip Chandler
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/westberkshire/
 permalink: lugs/South-East/West Berkshire - Newbury/
+location:
+  latitude: 51.40
+  longitude: -1.32
 ---

--- a/_posts/0000-01-01-West Lothian.md
+++ b/_posts/0000-01-01-West Lothian.md
@@ -11,4 +11,7 @@ contact_address: mailto:affix@affix.me
 contact: Keiran Smith
 mailing_list: http://mailman.lug.org.uk/mailman/listinfo/westlothian
 permalink: lugs/Scotland/West Lothian/
+location:
+  latitude: 55.91
+  longitude: -3.55
 ---

--- a/_posts/0000-01-01-West Wales.md
+++ b/_posts/0000-01-01-West Wales.md
@@ -11,4 +11,7 @@ contact_address: mailto:westwales-owner@mailman.lug.org.uk
 contact: Mike Sheldon
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/westwales/
 permalink: lugs/Wales/West Wales/
+location:
+  latitude: 52.42
+  longitude: -4.08
 ---

--- a/_posts/0000-01-01-West Yorkshire.md
+++ b/_posts/0000-01-01-West Yorkshire.md
@@ -11,4 +11,7 @@ contact_address: mailto:wylug@wylug.org.uk
 contact: WYLUG
 mailing_list: http://www.wylug.org.uk/about/mailing-lists/
 permalink: lugs/Yorkshire-and-Humber/West Yorkshire/
+location:
+  latitude: 53.80
+  longitude: -1.55
 ---

--- a/_posts/0000-01-01-Wigan and St. Helens.md
+++ b/_posts/0000-01-01-Wigan and St. Helens.md
@@ -11,4 +11,7 @@ contact_address: mailto:paul@all-the-johnsons.co.uk
 contact: Paul F. Johnson
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/wishlug/
 permalink: lugs/North-West/Wigan and St. Helens/
+location:
+  latitude: 53.55
+  longitude: -2.63
 ---

--- a/_posts/0000-01-01-Wolverhampton.md
+++ b/_posts/0000-01-01-Wolverhampton.md
@@ -11,4 +11,7 @@ contact_address: ron@wellsted.org.uk
 contact: Ron Wellsted
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/wolveslug/
 permalink: lugs/West-Midlands/Wolverhampton/
+location:
+  latitude: 52.59
+  longitude: -2.13
 ---

--- a/_posts/0000-01-01-Worcester.md
+++ b/_posts/0000-01-01-Worcester.md
@@ -11,4 +11,7 @@ contact_address: mailto:leo@mozilla.org.uk
 contact: Leo McArdle
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/worcester/
 permalink: lugs/West-Midlands/Worcester/
+location:
+  latitude: 52.19
+  longitude: -2.22
 ---

--- a/index.md
+++ b/index.md
@@ -8,6 +8,8 @@ ref: home
 The UK Linux User Groups organisation, also known as lug.org.uk, is dedicated to providing technical services for User, Support or Interest Groups 
 who are interested in, or advocate for Permissive Licenses (e.g. Free Software, Open Source Software and Linux Distribution groups) in the United Kingdom.
 
+{% google_map src="_posts" height="500" class="center-image" %}
+
 [Our list of Linux User Groups or other associated groups in the United Kingdom is available from this page](lugs).
 
 We are able to offer to groups free hosting of web sites and email addresses, run mailing lists and provide DNS hosting services.


### PR DESCRIPTION
This uses the Google Maps API - I'd prefer OpenStreetMap, but couldn't immediately see a jekyll plugin that would do that!  It should be fairly easy to port later...

As a consequence, this needs an API key in the config file.  I created one that I've restricted to requests from lug.org.uk domains.