### PR TITLE
Update 0000-01-01-Tyneside (Newcastle).md

### DIFF
--- a/_posts/0000-01-01-Tyneside (Newcastle).md
+++ b/_posts/0000-01-01-Tyneside (Newcastle).md
@@ -8,8 +8,8 @@ last_update: 12/2009
 categories: North-East
 url: http://lug.org.uk/node/87
 contact_address: mailto:contact@tyneside.lug.org.uk
-contact: Brian Ronald
-mailing_list: http://tyneside.lug.org.uk/mailman/listinfo
+contact: Tyneside Lugmasters
+mailing_list: https://mailman.lug.org.uk/pipermail/tyneside/
 permalink: lugs/North-East/Tyneside (Newcastle)/
 location:
   latitude: 54.98


### PR DESCRIPTION
Change Tyneside mailing list address to the one now hosted by lug.org.uk and change contact name, requested by Derek Frost (22/5/2018).  Resolves #41 