### PR TITLE
Website checks and updates

### DIFF
--- a/_posts/0000-01-01-Anglian LUG.md
+++ b/_posts/0000-01-01-Anglian LUG.md
@@ -1,15 +1,15 @@
 ---
 layout: lug
 title: Anglian LUG
-website: http://www.alug.org.uk
+website: https://www.alug.org.uk
 established_date: 1999/05
 status: Active
 last_update: 12/2009
 categories: East
-url: http://lug.org.uk/node/43
+url: https://lug.org.uk/node/43
 contact_address: mailto:main-admin@lists.alug.org.uk
 contact: ALUG Admin Team
-mailing_list: http://lists.alug.org.uk/mailman/listinfo/main
+mailing_list: https://lists.alug.org.uk/mailman/listinfo/main
 permalink: lugs/East/Anglian LUG/
 location:
   latitude: 52.63

--- a/_posts/0000-01-01-Ayrshire.md
+++ b/_posts/0000-01-01-Ayrshire.md
@@ -1,7 +1,7 @@
 ---
 layout: lug
 title: Ayrshire
-website: http://ayrshire.lug.org.uk
+website: https://ayrshire.lug.org.uk
 established_date: 2019/04
 status: Active
 last_update: 04/2019

--- a/_posts/0000-01-01-Ayrshire.md
+++ b/_posts/0000-01-01-Ayrshire.md
@@ -1,7 +1,7 @@
 ---
 layout: lug
 title: Ayrshire
-website: https://ayrshire.lug.org.uk
+website: http://ayrshire.lug.org.uk
 established_date: 2019/04
 status: Active
 last_update: 04/2019

--- a/_posts/0000-01-01-Berkshire & Thames Valley Silicon Corridor.md
+++ b/_posts/0000-01-01-Berkshire & Thames Valley Silicon Corridor.md
@@ -1,15 +1,15 @@
 ---
 layout: lug
 title: Berkshire & Thames Valley ("Silicon Corridor")
-website: http://sclug.org.uk
+website: https://sclug.org.uk
 established_date: 1995/06
 status: Active
 last_update: 12/2009
 categories: South-East
-url: http://lug.org.uk/node/114
+url: https://lug.org.uk/node/114
 contact_address: mailto:tmdg@tmdg.co.uk
 contact: Tom Dawes-Gamble
-mailing_list: http://sclug.org.uk/mailman/listinfo
+mailing_list: https://sclug.org.uk/mailman/listinfo
 permalink: lugs/South-East/Berkshire and Thames Valley - Silicon Corridor/
 location:
   latitude: 51.45

--- a/_posts/0000-01-01-Birmingham.md
+++ b/_posts/0000-01-01-Birmingham.md
@@ -1,15 +1,15 @@
 ---
 layout: lug
 title: Birmingham
-website: http://birmingham.lug.org.uk
+website: https://birmingham.lug.org.uk
 established_date: 2001/06
 status: Active
 last_update: 09/2016
 categories: West-Midlands
-url: http://lug.org.uk/node/149
+url: https://lug.org.uk/node/149
 contact_address: mailto:bhamlug@autotrain.org
 contact: LUG Master
-mailing_list: http://mailman.lug.org.uk/mailman/listinfo/sb
+mailing_list: https://mailman.lug.org.uk/mailman/listinfo/sb
 permalink: lugs/West-Midlands/Birmingham/
 location:
   latitude: 52.49

--- a/_posts/0000-01-01-Birmingham.md
+++ b/_posts/0000-01-01-Birmingham.md
@@ -1,7 +1,7 @@
 ---
 layout: lug
 title: Birmingham
-website: https://birmingham.lug.org.uk
+website: https://www.birminghamlug.org.uk/
 established_date: 2001/06
 status: Active
 last_update: 09/2016

--- a/_posts/0000-01-01-Bradford.md
+++ b/_posts/0000-01-01-Bradford.md
@@ -1,12 +1,12 @@
 ---
 layout: lug
 title: Bradford
-website: http://bradlug.co.uk/
+website: https://bradlug.co.uk/
 established_date: 2008/08
 status: Active
 last_update: 12/2009
 categories: Yorkshire-and-Humber
-url: http://lug.org.uk/node/123
+url: https://lug.org.uk/node/123
 contact_address: mailto:admin@bradlug.co.uk
 contact: David Carpenter
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/bradford/

--- a/_posts/0000-01-01-Bristol and Bath.md
+++ b/_posts/0000-01-01-Bristol and Bath.md
@@ -1,7 +1,7 @@
 ---
 layout: lug
 title: Bristol and Bath
-website: https://www.bristol.lug.org.uk
+website: https://bristol.lug.org.uk
 established_date: 1998/06
 status: Active
 last_update: 02/2019

--- a/_posts/0000-01-01-Bristol and Bath.md
+++ b/_posts/0000-01-01-Bristol and Bath.md
@@ -1,12 +1,12 @@
 ---
 layout: lug
 title: Bristol and Bath
-website: http://www.bristol.lug.org.uk
+website: https://www.bristol.lug.org.uk
 established_date: 1998/06
 status: Active
 last_update: 02/2019
 categories: South-West
-url: http://lug.org.uk/node/140
+url: https://lug.org.uk/node/140
 contact_address: mailto:bristollug.contact@dfear.co.uk
 contact: David Fear
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/bristol/

--- a/_posts/0000-01-01-Chelmer Linux and Android Users Group.md
+++ b/_posts/0000-01-01-Chelmer Linux and Android Users Group.md
@@ -1,12 +1,12 @@
 ---
 layout: lug
 title: Chelmer Linux and Android Users Group
-website: http://www.linkedin.com/groups/Chelmer-Linux-Android-Users-Group-3963756
+website: https://www.linkedin.com/groups/Chelmer-Linux-Android-Users-Group-3963756
 established_date: 2011/06
 status: Starting
 last_update: 06/2011
 categories: South-East
-url: http://lug.org.uk/node/178
+url: https://lug.org.uk/node/178
 contact_address: mailto:lugmaster@chelmer.lug.org.uk
 contact: Martin Houston
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/chelmer/

--- a/_posts/0000-01-01-Chelmer Linux and Android Users Group.md
+++ b/_posts/0000-01-01-Chelmer Linux and Android Users Group.md
@@ -1,7 +1,6 @@
 ---
 layout: lug
 title: Chelmer Linux and Android Users Group
-website: https://www.linkedin.com/groups/Chelmer-Linux-Android-Users-Group-3963756
 established_date: 2011/06
 status: Starting
 last_update: 06/2011

--- a/_posts/0000-01-01-Chester.md
+++ b/_posts/0000-01-01-Chester.md
@@ -1,12 +1,12 @@
 ---
 layout: lug
 title: Chester
-website: http://chesterlug.org.uk/
+website: https://chesterlug.org.uk/
 established_date: 2006/07
 status: Active
 last_update: 09/2012
 categories: North-West
-url: http://lug.org.uk/node/72
+url: https://lug.org.uk/node/72
 contact_address: mailto:les.pritchard@gmail.com
 contact: Les Pritchard
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/chester/

--- a/_posts/0000-01-01-Colchester.md
+++ b/_posts/0000-01-01-Colchester.md
@@ -1,12 +1,12 @@
 ---
 layout: lug
 title: Colchester
-website: http://www.colchester.lug.org.uk
+website: https://colchester.lug.org.uk
 established_date: 2004/11
 status: Active
 last_update: 12/2009
 categories: East
-url: http://lug.org.uk/node/47
+url: https://lug.org.uk/node/47
 contact_address: mailto:colchester@lug.org.uk
 contact: Gary Kearley
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/colchester/

--- a/_posts/0000-01-01-Colchester.md
+++ b/_posts/0000-01-01-Colchester.md
@@ -1,7 +1,6 @@
 ---
 layout: lug
 title: Colchester
-website: https://colchester.lug.org.uk
 established_date: 2004/11
 status: Active
 last_update: 12/2009

--- a/_posts/0000-01-01-Cowley Club, Brighton.md
+++ b/_posts/0000-01-01-Cowley Club, Brighton.md
@@ -1,7 +1,7 @@
 ---
 layout: lug
 title: Cowley Club, Brighton
-website: https://cowleyclub.org.uk/?Library:Free_Software_Clinic
+website: https://cowley.club/news/event/free-software-clinic/
 established_date: ''
 status: Active
 last_update: 10/2015

--- a/_posts/0000-01-01-Cowley Club, Brighton.md
+++ b/_posts/0000-01-01-Cowley Club, Brighton.md
@@ -1,12 +1,12 @@
 ---
 layout: lug
 title: Cowley Club, Brighton
-website: http://cowleyclub.org.uk/?Library:Free_Software_Clinic
+website: https://cowleyclub.org.uk/?Library:Free_Software_Clinic
 established_date: ''
 status: Active
 last_update: 10/2015
 categories: South-East
-url: http://lug.org.uk/node/187
+url: https://lug.org.uk/node/187
 contact_address: mailto:cowleylibrary@riseup.net
 contact: Cowley Library Volunteers
 permalink: lugs/South-East/Cowley Club, Brighton/

--- a/_posts/0000-01-01-Doncaster & Scunthorpe.md
+++ b/_posts/0000-01-01-Doncaster & Scunthorpe.md
@@ -1,12 +1,12 @@
 ---
 layout: lug
 title: Doncaster & Scunthorpe
-website: http://www.scundog.org/
+website: https://www.scundog.org/
 established_date: 1999/07
 status: Active
 last_update: 12/2009
 categories: Yorkshire-and-Humber
-url: http://lug.org.uk/node/129
+url: https://lug.org.uk/node/129
 contact_address: mailto:webmaster@scundog.org
 contact: Shaun Holt
 permalink: lugs/Yorkshire-and-Humber/Doncaster & Scunthorpe/

--- a/_posts/0000-01-01-Doncaster & Scunthorpe.md
+++ b/_posts/0000-01-01-Doncaster & Scunthorpe.md
@@ -1,7 +1,6 @@
 ---
 layout: lug
 title: Doncaster & Scunthorpe
-website: https://www.scundog.org/
 established_date: 1999/07
 status: Active
 last_update: 12/2009

--- a/_posts/0000-01-01-Leicester.md
+++ b/_posts/0000-01-01-Leicester.md
@@ -1,7 +1,7 @@
 ---
 layout: lug
 title: Leicester
-website: http://www.leicester.lug.org.uk
+website: https://www.leicester.lug.org.uk/
 established_date: 1999/09
 status: Active
 last_update: 12/2009

--- a/_posts/0000-01-01-Lincolnshire.md
+++ b/_posts/0000-01-01-Lincolnshire.md
@@ -1,7 +1,7 @@
 ---
 layout: lug
 title: Lincolnshire
-website: http://lincslug.org.uk
+website: https://lincslug.org.uk/
 established_date: ''
 status: Starting
 last_update: 03/2014

--- a/_posts/0000-01-01-Liverpool (LivLUG).md
+++ b/_posts/0000-01-01-Liverpool (LivLUG).md
@@ -1,7 +1,7 @@
 ---
 layout: lug
 title: Liverpool (LivLUG)
-website: http://www.livlug.org.uk
+website: https://livlug.org.uk/
 established_date: 2004/11
 status: Active
 last_update: 01/2015

--- a/_posts/0000-01-01-Manchester Free Software.md
+++ b/_posts/0000-01-01-Manchester Free Software.md
@@ -1,15 +1,15 @@
 ---
 layout: lug
 title: Manchester Free Software
-website: http://libreplanet.org/wiki/Manchester
+website: https://libreplanet.org/wiki/Manchester
 established_date: 2007/11
 status: Active
 last_update: 10/2010
 categories: North-West
-url: http://lug.org.uk/node/173
+url: https://lug.org.uk/node/173
 contact_address: mailto:fsuk-manchester-team@nongnu.org
 contact: Team MFS
-mailing_list: http://lists.nongnu.org/mailman/listinfo/fsuk-manchester
+mailing_list: https://lists.nongnu.org/mailman/listinfo/fsuk-manchester
 permalink: lugs/North-West/Manchester Free Software/
 location:
   latitude: 53.48

--- a/_posts/0000-01-01-Milton Keynes.md
+++ b/_posts/0000-01-01-Milton Keynes.md
@@ -1,7 +1,7 @@
 ---
 layout: lug
 title: Milton Keynes
-website: http://www.mk.lug.org.uk
+website: https://www.mk.lug.org.uk/
 established_date: 1999/01
 status: Active
 last_update: 12/2009

--- a/_posts/0000-01-01-Newark.md
+++ b/_posts/0000-01-01-Newark.md
@@ -1,7 +1,6 @@
 ---
 layout: lug
 title: Newark
-website: https://www.facebook.com/groups/284465954978157/
 established_date: 2001/06
 status: Active
 last_update: 07/2016

--- a/_posts/0000-01-01-North East Worcestershire.md
+++ b/_posts/0000-01-01-North East Worcestershire.md
@@ -1,7 +1,7 @@
 ---
 layout: lug
 title: North-East Worcestershire
-website: http://www.new.lug.org.uk
+website: https://www.new.lug.org.uk/
 established_date: 2011/01
 status: Starting
 last_update: 12/2011

--- a/_posts/0000-01-01-Nottingham.md
+++ b/_posts/0000-01-01-Nottingham.md
@@ -1,7 +1,7 @@
 ---
 layout: lug
 title: Nottingham
-website: http://www.nottingham.lug.org.uk
+website: https://nlug.ml1.co.uk/
 established_date: 2000/03
 status: Active
 last_update: 05/2012

--- a/_posts/0000-01-01-Portsmouth and South East Hampshire.md
+++ b/_posts/0000-01-01-Portsmouth and South East Hampshire.md
@@ -2,9 +2,9 @@
 layout: lug
 title: Portsmouth and South-East Hampshire
 website: http://www.portsmouth.lug.org.uk
-established_date: ''
+established_date: 2005/01
 status: Active
-last_update: 11/2016
+last_update: 10/2020
 categories: South-East
 url: http://lug.org.uk/node/128
 contact_address: mailto:paul@aptanet.com

--- a/_posts/0000-01-01-Rossendale LUG.md
+++ b/_posts/0000-01-01-Rossendale LUG.md
@@ -1,15 +1,15 @@
 ---
 layout: lug
 title: Rossendale LUG
-website: http://www.rosslug.org.uk
+website: https://www.rosslug.org.uk
 established_date: 2010/10
 status: Active
 last_update: 02/2014
 categories: North-West
-url: http://lug.org.uk/node/174
+url: https://lug.org.uk/node/174
 contact_address: mailto:admin@rosslug.org.uk
 contact: Jon Archer
-mailing_list: http://www.rosslug.org.uk/mailman/listinfo/rosslug
+mailing_list: https://www.rosslug.org.uk/mailman/listinfo/rosslug
 permalink: lugs/North-West/Rossendale LUG/
 location:
   latitude: 53.69

--- a/_posts/0000-01-01-Rossendale LUG.md
+++ b/_posts/0000-01-01-Rossendale LUG.md
@@ -1,7 +1,6 @@
 ---
 layout: lug
 title: Rossendale LUG
-website: https://www.rosslug.org.uk
 established_date: 2010/10
 status: Active
 last_update: 02/2014

--- a/_posts/0000-01-01-Rustington.md
+++ b/_posts/0000-01-01-Rustington.md
@@ -1,7 +1,7 @@
 ---
 layout: lug
 title: Rustington
-website: http://www.rustington.lug.org.uk
+website: https://www.rustington.lug.org.uk/
 established_date: 2010/10
 status: Starting
 last_update: 10/2010

--- a/_posts/0000-01-01-Scottish.md
+++ b/_posts/0000-01-01-Scottish.md
@@ -1,12 +1,12 @@
 ---
 layout: lug
 title: Scottish
-website: http://scotlug.org.uk
+website: https://scotlug.org.uk
 established_date: 1998/02
 status: Active
 last_update: 12/2009
 categories: Scotland
-url: http://lug.org.uk/node/116
+url: https://lug.org.uk/node/116
 contact_address: mailto:info@scotlug.org.uk
 contact: Kenny Duffus
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/scottish/

--- a/_posts/0000-01-01-Sheffield.md
+++ b/_posts/0000-01-01-Sheffield.md
@@ -1,7 +1,7 @@
 ---
 layout: lug
 title: Sheffield
-website: https://www.sheflug.org.uk/
+website: https://www.sheflug.org.uk/indexpage/
 established_date: 1999/01
 status: Active
 last_update: 12/2009

--- a/_posts/0000-01-01-Sheffield.md
+++ b/_posts/0000-01-01-Sheffield.md
@@ -1,15 +1,15 @@
 ---
 layout: lug
 title: Sheffield
-website: http://www.sheflug.org.uk/
+website: https://www.sheflug.org.uk/
 established_date: 1999/01
 status: Active
 last_update: 12/2009
 categories: Yorkshire-and-Humber
-url: http://lug.org.uk/node/136
+url: https://lug.org.uk/node/136
 contact_address: mailto:enquiries@sheflug.org.uk
 contact: Richard Ibbotson
-mailing_list: http://sheflug.org.uk/mailman/listinfo/sheflug_sheflug.org.uk
+mailing_list: https://sheflug.org.uk/mailman/listinfo/sheflug_sheflug.org.uk
 permalink: lugs/Yorkshire-and-Humber/Sheffield/
 location:
   latitude: 53.38

--- a/_posts/0000-01-01-Shropshire.md
+++ b/_posts/0000-01-01-Shropshire.md
@@ -1,12 +1,12 @@
 ---
 layout: lug
 title: Shropshire
-website: http://shropshirelug.wordpress.com/
+website: https://shropshirelug.wordpress.com/
 established_date: 2000/02
 status: Active
 last_update: 11/2013
 categories: West-Midlands
-url: http://lug.org.uk/node/163
+url: https://lug.org.uk/node/163
 contact_address: mailto:davekh@gmail.com
 contact: Dave Harris
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/shropshire

--- a/_posts/0000-01-01-South Wales.md
+++ b/_posts/0000-01-01-South Wales.md
@@ -1,12 +1,12 @@
 ---
 layout: lug
 title: South Wales
-website: http://www.swlug.org.uk
+website: https://www.swlug.org.uk
 established_date: 2002/01
 status: Active
 last_update: 11/2013
 categories: Wales
-url: http://lug.org.uk/node/154
+url: https://lug.org.uk/node/154
 mailing_list: http://mailman.lug.org.uk/mailman/listinfo/swlug/
 permalink: lugs/Wales/South Wales/
 location:

--- a/_posts/0000-01-01-Southend-on-Sea.md
+++ b/_posts/0000-01-01-Southend-on-Sea.md
@@ -1,12 +1,12 @@
 ---
 layout: lug
 title: Southend-on-Sea
-website: http://soslug.org
+website: https://soslug.org
 established_date: 2003/03
 status: Active
 last_update: 12/2018
 categories: South-East
-url: http://lug.org.uk/node/53
+url: https://lug.org.uk/node/53
 contact_address: mailto:linux@soslug.org
 contact: Derek Shaw
 mailing_list: ''

--- a/_posts/0000-01-01-Surrey.md
+++ b/_posts/0000-01-01-Surrey.md
@@ -1,12 +1,12 @@
 ---
 layout: lug
 title: Surrey
-website: http://www.surrey.lug.org.uk
+website: https://www.surrey.lug.org.uk
 established_date: 2000/02
 status: Active
 last_update: 04/2010
 categories: South-East
-url: http://lug.org.uk/node/130
+url: https://lug.org.uk/node/130
 contact_address: mailto:surrey-owner@mailman.lug.org.uk
 contact: Surrey LUG admin team
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/surrey/

--- a/_posts/0000-01-01-West Yorkshire.md
+++ b/_posts/0000-01-01-West Yorkshire.md
@@ -1,15 +1,15 @@
 ---
 layout: lug
 title: West Yorkshire
-website: http://www.wylug.org.uk/
+website: https://www.wylug.org.uk/
 established_date: 1998/01
 status: Active
 last_update: 04/2010
 categories: Yorkshire-and-Humber
-url: http://lug.org.uk/node/138
+url: https://lug.org.uk/node/138
 contact_address: mailto:wylug@wylug.org.uk
 contact: WYLUG
-mailing_list: http://www.wylug.org.uk/about/mailing-lists/
+mailing_list: https://www.wylug.org.uk/about/mailing-lists/
 permalink: lugs/Yorkshire-and-Humber/West Yorkshire/
 location:
   latitude: 53.80

--- a/_posts/0000-01-01-Wolverhampton.md
+++ b/_posts/0000-01-01-Wolverhampton.md
@@ -1,12 +1,12 @@
 ---
 layout: lug
 title: Wolverhampton
-website: http://wolveslug.org.uk/
+website: https://wolveslug.org.uk/
 established_date: 1999/11
 status: Active
 last_update: 12/2009
 categories: West-Midlands
-url: http://lug.org.uk/node/165
+url: https://lug.org.uk/node/165
 contact_address: mailto:adamsweet@gmail.com
 contact: Adam Sweet
 mailing_list: https://mailman.lug.org.uk/mailman/listinfo/wolves/


### PR DESCRIPTION
The last pull request was done in error (sorry, missed Github setting to the base repository and not my local one).
All websites have been checked and upgraded to https where they work. A two don't have websites at the end, but if there is the same result on http and https (or https is more informative) I have changed the link. A couple are to domains no longer registered or pages on social networks that no longer exist so I have removed these. A few more have new sites or redirect to sites off lug.org.uk so these have been updated to the resulting URL. Blackpool looks to be in the process of moving to a new site as a combined Makerspace, but I have left the link to the existing site with the explanation.