### PR TITLE
Enable email notifications to Admin about failed builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,10 @@ sudo: false # route your build to the container-based infrastructure for a faste
 
 cache: bundler # caching bundler gem packages will speed up build
 
-# Optional: disable email notifications about the outcome of your builds
+# Optional: enable email notifications about failed builds
 notifications:
-  email: false
+  email:
+    recipients:
+      - admin@mailman.lug.org.uk
+    on_success: never # default: change
+    on_failure: always # default: always


### PR DESCRIPTION
Ensure that the Admin mailing list is notified about build failures for the website by the CI.